### PR TITLE
Add a set of worker routines for handling concurrency.

### DIFF
--- a/executor_resolve_test.go
+++ b/executor_resolve_test.go
@@ -115,55 +115,6 @@ func TestExecutesResolveFunction_UsesProvidedResolveFunction(t *testing.T) {
 	}
 }
 
-func TestExecutesResolveFunction_UsesProvidedResolveFunction_ResolveFunctionIsDeferred(t *testing.T) {
-	schema := testSchema(t, &graphql.Field{
-		Type: graphql.String,
-		Args: graphql.FieldConfigArgument{
-			"aStr": &graphql.ArgumentConfig{Type: graphql.String},
-			"aInt": &graphql.ArgumentConfig{Type: graphql.Int},
-		},
-		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-			return func() (interface{}, error) {
-				b, err := json.Marshal(p.Args)
-				return string(b), err
-			}, nil
-		},
-	})
-
-	expected := map[string]interface{}{
-		"test": "{}",
-	}
-	result := graphql.Do(graphql.Params{
-		Schema:        schema,
-		RequestString: `{ test }`,
-	})
-	if !reflect.DeepEqual(expected, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
-	}
-
-	expected = map[string]interface{}{
-		"test": `{"aStr":"String!"}`,
-	}
-	result = graphql.Do(graphql.Params{
-		Schema:        schema,
-		RequestString: `{ test(aStr: "String!") }`,
-	})
-	if !reflect.DeepEqual(expected, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
-	}
-
-	expected = map[string]interface{}{
-		"test": `{"aInt":-123,"aStr":"String!"}`,
-	}
-	result = graphql.Do(graphql.Params{
-		Schema:        schema,
-		RequestString: `{ test(aInt: -123, aStr: "String!") }`,
-	})
-	if !reflect.DeepEqual(expected, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result.Data))
-	}
-}
-
 func TestExecutesResolveFunction_UsesProvidedResolveFunction_SourceIsStruct_WithoutJSONTags(t *testing.T) {
 
 	// For structs without JSON tags, it will map to upper-cased exported field names

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/GannettDigital/graphql
+
+go 1.12

--- a/graphql.go
+++ b/graphql.go
@@ -9,6 +9,12 @@ import (
 	"github.com/GannettDigital/graphql/language/source"
 )
 
+const defaultWorkers = 100
+
+// TODO I should build a defaultManager and allow for one passed in as part of the params
+
+var manager *resolveManager
+
 type Params struct {
 	// The GraphQL type system to use when validating and executing a query.
 	Schema Schema
@@ -38,6 +44,10 @@ type Params struct {
 }
 
 func Do(p Params) *Result {
+	if manager == nil {
+		manager = newResolveManager(defaultWorkers)
+	}
+
 	source := source.NewSource(&source.Source{
 		Body: []byte(p.RequestString),
 		Name: "GraphQL request",
@@ -63,6 +73,7 @@ func Do(p Params) *Result {
 		OperationName: p.OperationName,
 		Args:          p.VariableValues,
 		Context:       p.Context,
+		manager:       manager,
 	}
 
 	var cost int

--- a/lists_test.go
+++ b/lists_test.go
@@ -252,7 +252,7 @@ func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{"test": nil},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -322,7 +322,9 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 	}
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{
+				"test": nil,
+			},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -417,7 +419,9 @@ func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
-				"test": nil,
+				"test": []interface{}{
+					1, nil, 2,
+				},
 			},
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -482,7 +486,9 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
-				"test": nil,
+				"test": []interface{}{
+					1, nil, 2,
+				},
 			},
 		},
 		Errors: []gqlerrors.FormattedError{
@@ -594,7 +600,11 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 	}
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{
+				"test": []interface{}{
+					1, nil, 2,
+				},
+			},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -615,7 +625,9 @@ func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{
+				"test": nil,
+			},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -666,7 +678,11 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 	}
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{
+				"test": []interface{}{
+					1, nil, 2,
+				},
+			},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -692,7 +708,9 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 	}
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{
+				"test": nil,
+			},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{

--- a/manager.go
+++ b/manager.go
@@ -1,0 +1,160 @@
+package graphql
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GannettDigital/graphql/gqlerrors"
+	"github.com/GannettDigital/graphql/language/ast"
+)
+
+const (
+	requestQueueBuffer = 10
+	workerMaxRequests  = 10000
+	workerStartDelay   = 50 * time.Microsecond
+)
+
+// completeRequest contains the information needed to complete a field.
+// A completeRequest is passed to a resolveManager worker which processes the request.
+// This is only used when completing multiple items concurrently such as needed for a list
+type completeRequest struct {
+	index    int
+	response chan<- completeResponse
+
+	eCtx       *executionContext
+	returnType Type
+	fieldASTs  []*ast.Field
+	info       ResolveInfo
+	value      interface{}
+}
+
+// completeResponse is the type containing the completion response which is sent over a channel as workers finish
+// processing.
+type completeResponse struct {
+	index  int
+	result interface{}
+}
+
+// resolveRequest contains the information needed to resolve a field.
+// A resolveRequest is passed to a resolveManager worker which processes the request.
+type resolveRequest struct {
+	fn       FieldResolveFn
+	name     string
+	params   ResolveParams
+	response chan<- resolverResponse
+}
+
+// resolverResponse is the type containing the resolver response which is sent over a channel as workers finish
+// processing.
+type resolverResponse struct {
+	err    error
+	name   string
+	result interface{}
+}
+
+// resolveManager runs resolve functions and completeValue requests in a set of worker go routines.
+// Having a set number of workers limits the churn of go routines while still providing parallel resolving of results
+// which is key to performance when some resolving requires a network call.
+//
+// The nature of the GraphQL resolving code is that a single resolve call could end up calling other resolve calls
+// as part of it. This means to avoid a full deadlock a hard limit on the number of workers can't be set, instead
+// a slight buffer and a slight delay is added to give preference to reusing workers over creating new.
+//
+// A spike in traffic can lead to an increase in the number of workers many of which are subsequently idle. To
+// allow slowly dropping back down to a reasonable pool workers will exit after processing a set number of requests.
+// The original set of workers will always recreate a new worker on exit to avoid the number dropping too much.
+type resolveManager struct {
+	completeRequests chan completeRequest
+	once             sync.Once
+	quit             chan bool
+	resolveRequests  chan resolveRequest
+}
+
+func newResolveManager(startingWorkers int) *resolveManager {
+	manager := &resolveManager{
+		completeRequests: make(chan completeRequest, requestQueueBuffer),
+		once:             sync.Once{},
+		quit:             make(chan bool),
+		resolveRequests:  make(chan resolveRequest, requestQueueBuffer),
+	}
+
+	for i := 0; i < startingWorkers; i++ {
+		go manager.newWorker(true)
+	}
+
+	return manager
+}
+
+func (manager *resolveManager) completeRequest(req completeRequest) {
+	for {
+		select {
+		case manager.completeRequests <- req:
+			return
+		case <-time.After(workerStartDelay):
+			go manager.newWorker(false)
+		}
+	}
+}
+
+func (manager *resolveManager) resolveRequest(name string, response chan<- resolverResponse, fn FieldResolveFn, params ResolveParams) {
+	req := resolveRequest{
+		fn:       fn,
+		name:     name,
+		params:   params,
+		response: response,
+	}
+
+	for {
+		select {
+		case manager.resolveRequests <- req:
+			return
+		case <-time.After(workerStartDelay):
+			go manager.newWorker(false)
+		}
+	}
+}
+
+func (manager *resolveManager) newWorker(revive bool) {
+	// This is a simplistic means of dropping the number of workers back down eventually after a spike but other
+	// methods such as added a timer caused a performance impact.
+	for i := 0; i < workerMaxRequests; i++ {
+		select {
+		case <-manager.quit:
+			return
+		case req := <-manager.completeRequests:
+			result := completeValueCatchingError(req.eCtx, req.returnType, req.fieldASTs, req.info, req.value)
+			req.response <- completeResponse{index: req.index, result: result}
+		case req := <-manager.resolveRequests:
+			manager.resolve(req)
+		}
+	}
+	if revive {
+		go manager.newWorker(revive)
+	}
+}
+
+func (manager *resolveManager) resolve(req resolveRequest) {
+	defer func() {
+		if r := recover(); r != nil {
+			var err error
+			if r, ok := r.(string); ok {
+				err = NewLocatedError(
+					fmt.Sprintf("%v", r),
+					FieldASTsToNodeASTs(req.params.Info.FieldASTs),
+				)
+			}
+			if r, ok := r.(error); ok {
+				err = gqlerrors.FormatError(r)
+			}
+			req.response <- resolverResponse{name: req.name, err: err}
+		}
+	}()
+
+	result, err := req.fn(req.params)
+	req.response <- resolverResponse{name: req.name, result: result, err: err}
+}
+
+func (manager *resolveManager) stop() {
+	manager.once.Do(func() { close(manager.quit) })
+}

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -551,10 +551,10 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest":               nil,
-			"promiseNest":        nil,
-			"anotherNest":        nil,
-			"anotherPromiseNest": nil,
+			"nest":               map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": nil}}}},
+			"promiseNest":        map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": nil}}}},
+			"anotherNest":        map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": nil}}}},
+			"anotherPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": nil}}}},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -678,7 +678,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{"nonNullSync": nil},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -716,7 +716,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest": nil,
+			"nest": map[string]interface{}{"nonNullPromise": nil},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -755,7 +755,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"promiseNest": nil,
+			"promiseNest": map[string]interface{}{"nonNullSync": nil},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -793,7 +793,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"promiseNest": nil,
+			"promiseNest": map[string]interface{}{"nonNullPromise": nil},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -949,10 +949,10 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 	`
 	expected := &graphql.Result{
 		Data: map[string]interface{}{
-			"nest":               nil,
-			"promiseNest":        nil,
-			"anotherNest":        nil,
-			"anotherPromiseNest": nil,
+			"nest":               map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullSync": nil}}}}},
+			"promiseNest":        map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullSync": nil}}}}},
+			"anotherNest":        map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullPromise": nil}}}}},
+			"anotherPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullNest": map[string]interface{}{"nonNullPromiseNest": map[string]interface{}{"nonNullPromise": nil}}}}},
 		},
 		Errors: []gqlerrors.FormattedError{
 			{
@@ -1009,7 +1009,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
       query Q { nonNullSync }
 	`
 	expected := &graphql.Result{
-		Data: nil,
+		Data: map[string]interface{}{"nonNullSync": nil},
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullSyncError,
@@ -1041,7 +1041,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
       query Q { nonNullPromise }
 	`
 	expected := &graphql.Result{
-		Data: nil,
+		Data: map[string]interface{}{"nonNullPromise": nil},
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullPromiseError,
@@ -1073,7 +1073,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
       query Q { nonNullSync }
 	`
 	expected := &graphql.Result{
-		Data: nil,
+		Data: map[string]interface{}{"nonNullSync": nil},
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
@@ -1105,7 +1105,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
       query Q { nonNullPromise }
 	`
 	expected := &graphql.Result{
-		Data: nil,
+		Data: map[string]interface{}{"nonNullPromise": nil},
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,


### PR DESCRIPTION
Previously go routines were made for many fields in each request
resulting in a huge number of routines created and destroyed. This
optimizes the concurrency allowing reusing of go routines but retaining
the flexibility to add more as demand requires.

Using panics to propagate errors is bad practice and though this change
does not fix that it tries not to continue the practice. This has
resulted in a slight behavior change for non-null fields that have a
null value. This still causes an error but the partial data returned
is different. The spec does not address what partial data is expected
in the case of an error so this does not change compliance.