### PR TITLE
Restore GraphQL spec compliant behavior limiting ints to 32bits.

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 // n.b. JavaScript's integers are safe between -(2^53 - 1) and 2^53 - 1 because
 // they are internally represented as IEEE 754 doubles.
 func coerceInt(value interface{}) interface{} {
-	// TODO this int32 limitation was removed to allow data in the system to properly work
 	switch value := value.(type) {
 	case bool:
 		if value == true {
@@ -22,6 +22,9 @@ func coerceInt(value interface{}) interface{} {
 		}
 		return 0
 	case int:
+		if value < int(math.MinInt32) || value > int(math.MaxInt32) {
+			return nil
+		}
 		return value
 	case *int:
 		return coerceInt(*value)
@@ -38,10 +41,16 @@ func coerceInt(value interface{}) interface{} {
 	case *int32:
 		return int(*value)
 	case int64:
+		if value < int64(math.MinInt32) || value > int64(math.MaxInt32) {
+			return nil
+		}
 		return int(value)
 	case *int64:
 		return coerceInt(*value)
 	case uint:
+		if value > math.MaxInt32 {
+			return nil
+		}
 		return int(value)
 	case *uint:
 		return coerceInt(*value)
@@ -54,18 +63,30 @@ func coerceInt(value interface{}) interface{} {
 	case *uint16:
 		return int(*value)
 	case uint32:
+		if value > uint32(math.MaxInt32) {
+			return nil
+		}
 		return int(value)
 	case *uint32:
 		return coerceInt(*value)
 	case uint64:
+		if value > uint64(math.MaxInt32) {
+			return nil
+		}
 		return int(value)
 	case *uint64:
 		return coerceInt(*value)
 	case float32:
+		if value < float32(math.MinInt32) || value > float32(math.MaxInt32) {
+			return nil
+		}
 		return int(value)
 	case *float32:
 		return coerceInt(*value)
 	case float64:
+		if value < float64(math.MinInt32) || value > float64(math.MaxInt32) {
+			return nil
+		}
 		return int(value)
 	case *float64:
 		return coerceInt(*value)

--- a/scalars_serialization_test.go
+++ b/scalars_serialization_test.go
@@ -35,7 +35,6 @@ type boolSerializationTest struct {
 }
 
 func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
-	t.Skip("skipping test until code is returned to spec compliance") //TODO
 	tests := []intSerializationTest{
 		{1, 1},
 		{0, 0},


### PR DESCRIPTION
This reverts commit 421e32daca2e1131482398ee625b2c0c489df0b4.